### PR TITLE
Mount permissions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    compose-ecs (0.0.11)
+    compose-ecs (0.0.13)
       gli (~> 2.13.2)
       json (~> 1.8.3)
 

--- a/compose-ecs.gemspec
+++ b/compose-ecs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'compose-ecs'
-  s.version       = '0.0.12'
+  s.version       = '0.0.13'
   s.date          = '2015-12-07'
   s.summary       = 'A bridge between docker-compose and AWS ECS Task Definitions'
   s.description   = 'A bridge between docker-compose and AWS ECS Task Definitions'

--- a/spec/composeecs_spec.rb
+++ b/spec/composeecs_spec.rb
@@ -54,6 +54,19 @@ describe ComposeECS do
       expect(JSON.parse(@compose.volumes).size).to eq(1)
       expect(JSON.parse(@compose.volumes).class).to equal(Array)
     end
+
+    it 'should not set readOnly to true on a mount point' do
+      expect(@compose.to_hash.first['containerDefinitions']
+      .find { |c| c['name'] == 'db' }['mountPoints']
+      .find { |m| m['containerPath'] == '/var/lib/mysql' }).to_not have_key('readOnly')
+    end
+
+    it 'should set readOnly to true on a mount point if specified' do
+      expect(@compose.to_hash.first['containerDefinitions']
+      .find { |c| c['name'] == 'db' }['mountPoints']
+      .find { |m| m['containerPath'] == '/var/lib/db' }['readOnly']).to be true 
+    end
+
   end
 
   context 'while parsing a valid docker-compose definition without volumes' do

--- a/spec/docker-compose.volumes.yml
+++ b/spec/docker-compose.volumes.yml
@@ -5,7 +5,7 @@ db:
    - "3306:3306"
   volumes:
     - /home/mysql:/var/lib/mysql
-    - /home/mysql:/var/lib/db
+    - /home/mysql:/var/lib/db:ro
   environment:
     MYSQL_ROOT_PASSWORD: password
 redis:


### PR DESCRIPTION
Add functionality to allow for filesystem permissions on mount points.

For example, in a docker-compose.yml file I can have

```
volumes:
    - /volumes/vol1:/var/data:ro
```

Which needs to translate into

```
"mountPoints": [
        {
          "sourceVolume": "ecs-volume-1",
          "containerPath": "/var/data",
          "readOnly": true
        }
```